### PR TITLE
Error calling getTinyIntTypeDeclarationSQL on MySQL database

### DIFF
--- a/src/Schema/Type/TinyintType.php
+++ b/src/Schema/Type/TinyintType.php
@@ -25,6 +25,10 @@ class TinyintType extends SmallIntType
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return $platform->getTinyIntTypeDeclarationSQL($fieldDeclaration);
+        if(method_exists($platform,'getTinyIntTypeDeclarationSQL')) {
+            return $platform->getTinyIntTypeDeclarationSQL($fieldDeclaration);
+        } else {
+            return $platform->getSmallIntTypeDeclarationSQL($fieldDeclaration);
+        }
     }
 }


### PR DESCRIPTION
When used on MysqlDatabase we have this error:

PHP Fatal error: Call to undefined method Doctrine\DBAL\Platforms\MySQL57Platform::getTinyIntTypeDeclarationSQL() in /home/myapp/vendor/euskadi31/schema/src/Schema/Type/TinyintType.php on line 28

Adding fallback methods to smallIntType more present on other platforms.