### PR TITLE
Evolution to manage MySQL 5.7 doctrine breakpoint

### DIFF
--- a/src/Schema/Driver/PDOMySql/Driver.php
+++ b/src/Schema/Driver/PDOMySql/Driver.php
@@ -21,4 +21,22 @@ class Driver extends BaseDriver
     {
         return new \Schema\Platform\MySqlPlatform();
     }
+
+    public function createDatabasePlatformForVersion($version)
+    {
+        if (false !== stripos($version, 'mariadb')) {
+            return $this->getDatabasePlatform();
+        }
+
+        $majorVersion = $versionParts['major'];
+        $minorVersion = isset($versionParts['minor']) ? $versionParts['minor'] : 0;
+        $patchVersion = isset($versionParts['patch']) ? $versionParts['patch'] : 0;
+        $version      = $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
+
+        if (version_compare($version, '5.7', '>=')) {
+            return new \Schema\Platform\MySQL57Platform();
+        }
+
+        return $this->getDatabasePlatform();
+    }
 }

--- a/src/Schema/Driver/PDOMySql/Driver.php
+++ b/src/Schema/Driver/PDOMySql/Driver.php
@@ -14,6 +14,7 @@
 namespace Schema\Driver\PDOMySql;
 
 use Doctrine\DBAL\Driver\PDOMySql\Driver as BaseDriver;
+use Doctrine\DBAL\DBALException;
 
 class Driver extends BaseDriver
 {
@@ -24,6 +25,13 @@ class Driver extends BaseDriver
 
     public function createDatabasePlatformForVersion($version)
     {
+        if ( ! preg_match('/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/', $version, $versionParts)) {
+            throw DBALException::invalidPlatformVersionSpecified(
+                $version,
+                '<major_version>.<minor_version>.<patch_version>'
+            );
+        }
+
         if (false !== stripos($version, 'mariadb')) {
             return $this->getDatabasePlatform();
         }

--- a/src/Schema/Platform/MySQL57Platform.php
+++ b/src/Schema/Platform/MySQL57Platform.php
@@ -1,11 +1,11 @@
 <?php
 /*
- * Copy of the evolution made in Doctrine for MySQL57 by Steve Müller <st.mueller@dzh-online.de>
+ * Original code from Axel Etcheverry <axel@etcheverry.biz>
  */
 
 namespace Schema\Platform;
 
-use Schema\Platform\MySqlPlatform as SchemaMySqlPlaforme;
+use Doctrine\DBAL\Platforms\MySQL57Platform as BaseMySqlPlatform;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 
@@ -16,39 +16,335 @@ use Doctrine\DBAL\Schema\TableDiff;
  * @link   www.doctrine-project.org
  * @since  2.5
  */
-class MySQL57Platform extends SchemaMySqlPlaforme
+class MySQL57Platform extends BaseMySqlPlatform
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    public function getTinyIntTypeDeclarationSQL(array $field)
     {
-        return array();
+        return 'TINYINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+    }
+
+    protected function _getCommonTextTypeDeclarationSQL(array $columnDef)
+    {
+        if (isset($columnDef['length']) && is_numeric($columnDef['length'])) {
+            return '(' . (int)$columnDef['length'] . ')';
+        }
+
+        return '';
+    }
+
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    {
+        $length = '';
+        if (isset($columnDef['length']) && is_numeric($columnDef['length'])) {
+            $length = '(' . (int)$columnDef['length'] . ')';
+        }
+
+        $autoinc = '';
+        if ( ! empty($columnDef['autoincrement'])) {
+            $autoinc = ' AUTO_INCREMENT';
+        }
+        $unsigned = (isset($columnDef['unsigned']) && $columnDef['unsigned']) ? ' UNSIGNED' : '';
+
+        return $length . $unsigned . $autoinc;
+    }
+
+    public function getBooleanTypeDeclarationSQL(array $field)
+    {
+        return 'TINYINT(1) UNSIGNED';
+    }
+
+    public function getDoubleDeclarationSQL(array $field)
+    {
+        return 'DOUBLE' . $this->_getCommonDoubleTypeDeclarationSQL($field);
+    }
+
+    public function getMediumIntTypeDeclarationSQL(array $field)
+    {
+        return 'MEDIUMINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+    }
+
+    public function getTinyTextTypeDeclarationSQL(array $field)
+    {
+        return 'TINYTEXT' . $this->_getCommonTextTypeDeclarationSQL($field);
+    }
+
+    public function getMediumTextTypeDeclarationSQL(array $field)
+    {
+        return 'MEDIUMTEXT' . $this->_getCommonTextTypeDeclarationSQL($field);
+    }
+
+    public function getLongTextTypeDeclarationSQL(array $field)
+    {
+        return 'LONGTEXT' . $this->_getCommonTextTypeDeclarationSQL($field);
+    }
+
+    public function _getCommonDoubleTypeDeclarationSQL(array $columnDef)
+    {
+        if (!isset($columnDef['precision'], $columnDef['scale'])) {
+            return '';
+        }
+
+
+        $columnDef['precision'] = (!isset($columnDef['precision']) || empty($columnDef['precision']))
+            ? 10 : $columnDef['precision'];
+        $columnDef['scale'] = ( ! isset($columnDef['scale']) || empty($columnDef['scale']))
+            ? 0 : $columnDef['scale'];
+
+        return '(' . $columnDef['precision'] . ', ' . $columnDef['scale'] . ')';
+    }
+
+    public function getDefaultValueDeclarationSQL($field)
+    {
+        $default = empty($field['notnull']) ? ' DEFAULT NULL' : '';
+
+        if (isset($field['default'])) {
+
+            if (isset($field['type'])) {
+                //var_dump((string)$field['type']);
+                if (in_array((string)$field['type'], array("Integer", "BigInteger", "SmallInteger", "Tinyint"))) {
+                    $default = " DEFAULT '" . $field['default'] . "'";
+                } else if ((string)$field['type'] == 'DateTime' && $field['default'] == $this->getCurrentTimestampSQL()) {
+                    $default = " DEFAULT " . $this->getCurrentTimestampSQL();
+                } else if ((string)$field['type'] == 'Timestamp' && $field['default'] == $this->getCurrentTimestampSQL()) {
+                    $default = " DEFAULT " . $this->getCurrentTimestampSQL();
+                } else if ((string) $field['type'] == 'Boolean') {
+                    $default = " DEFAULT '" . $this->convertBooleans($field['default']) . "'";
+                }
+            }
+        }
+        return $default;
+    }
+
+    public function getColumnDeclarationSQL($name, array $field)
+    {
+        if (isset($field['columnDefinition'])) {
+            $columnDef = $this->getCustomTypeDeclarationSQL($field);
+        } else {
+            $default = $this->getDefaultValueDeclarationSQL($field);
+
+            $charset = (isset($field['charset']) && $field['charset']) ?
+                    ' ' . $this->getColumnCharsetDeclarationSQL($field['charset']) : '';
+
+            $collation = (isset($field['collation']) && $field['collation']) ?
+                    ' ' . $this->getColumnCollationDeclarationSQL($field['collation']) : '';
+
+            $notnull = (isset($field['notnull']) && $field['notnull']) ? ' NOT NULL' : '';
+
+            $unique = (isset($field['unique']) && $field['unique']) ?
+                    ' ' . $this->getUniqueFieldDeclarationSQL() : '';
+
+            $check = (isset($field['check']) && $field['check']) ?
+                    ' ' . $field['check'] : '';
+
+            $typeDecl = $field['type']->getSqlDeclaration($field, $this);
+            $columnDef = $typeDecl . $charset . $notnull . $default . $unique . $check . $collation;
+        }
+
+        if ($this->supportsInlineColumnComments() && isset($field['comment']) && $field['comment']) {
+            $columnDef .= " COMMENT '" . $field['comment'] . "'";
+        }
+
+        return '`' . $name . '` ' . $columnDef;
+    }
+
+    public function getColumnDeclarationListSQL(array $fields)
+    {
+        $queryFields = array();
+
+        foreach ($fields as $fieldName => $field) {
+            $queryFields[] = "    " . $this->getColumnDeclarationSQL($fieldName, $field);
+        }
+
+        return PHP_EOL . implode(',' . PHP_EOL, $queryFields);
+
+        /*foreach ($queryFields as $queryField) {
+            $content .= "    " . $queryField . PHP_EOL;
+        }*/
+
+        //return $content;
+
+        //return implode(', ' . PHP_EOL, $queryFields);
+    }
+
+    public function getUniqueConstraintDeclarationSQL($name, Index $index)
+    {
+        if (count($index->getColumns()) === 0) {
+            throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
+        }
+
+        return '    CONSTRAINT `' . $name . '` UNIQUE ('
+             . $this->getIndexFieldDeclarationListSQL($index->getColumns())
+             . ')';
+    }
+
+    public function getIndexDeclarationSQL($name, Index $index)
+    {
+        $type = '';
+
+        if ($index->isUnique()) {
+            $type = 'UNIQUE ';
+        }
+
+        if (count($index->getColumns()) === 0) {
+            throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
+        }
+
+        return '    ' . $type . 'INDEX `' . $name . '` ('
+             . $this->getIndexFieldDeclarationListSQL($index->getColumns())
+             . ')';
+    }
+
+    public function getIndexFieldDeclarationListSQL(array $fields)
+    {
+        $ret = array();
+
+        foreach ($fields as $field => $definition) {
+            if (is_array($definition)) {
+                $ret[] = '`' . $field . '`';
+            } else {
+                $ret[] = '`' . $definition . '`';
+            }
+        }
+
+        return implode(', ', $ret);
+    }
+
+    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
+    {
+        if ($table instanceof Table) {
+            $table = $table->getQuotedName($this);
+        }
+
+        $query = 'ALTER TABLE `' . $table . '` ADD ' . $this->getForeignKeyDeclarationSQL($foreignKey);
+
+        return $query;
+    }
+
+
+    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    {
+        $sql = '';
+        if (strlen($foreignKey->getName())) {
+            $sql .= 'CONSTRAINT `' . $foreignKey->getQuotedName($this) . '` ';
+        }
+        $sql .= 'FOREIGN KEY (`';
+
+        if (count($foreignKey->getLocalColumns()) === 0) {
+            throw new \InvalidArgumentException("Incomplete definition. 'local' required.");
+        }
+        if (count($foreignKey->getForeignColumns()) === 0) {
+            throw new \InvalidArgumentException("Incomplete definition. 'foreign' required.");
+        }
+        if (strlen($foreignKey->getForeignTableName()) === 0) {
+            throw new \InvalidArgumentException("Incomplete definition. 'foreignTable' required.");
+        }
+
+        $sql .= implode('`, `', $foreignKey->getLocalColumns())
+              . '`) REFERENCES `'
+              . $foreignKey->getQuotedForeignTableName($this) . '` (`'
+              . implode('`, `', $foreignKey->getForeignColumns()) . '`)';
+
+        return $sql;
+    }
+
+    protected function _getCreateTableSQL($tableName, array $columns, array $options = array())
+    {
+        $queryFields = $this->getColumnDeclarationListSQL($columns);
+
+        if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
+            foreach ($options['uniqueConstraints'] as $index => $definition) {
+                $queryFields .= ', ' . PHP_EOL . $this->getUniqueConstraintDeclarationSQL($index, $definition);
+            }
+        }
+
+        // add all indexes
+        if (isset($options['indexes']) && ! empty($options['indexes'])) {
+            foreach($options['indexes'] as $index => $definition) {
+                $queryFields .= ', ' . PHP_EOL . $this->getIndexDeclarationSQL($index, $definition);
+            }
+        }
+
+        // attach all primary keys
+        if (isset($options['primary']) && ! empty($options['primary'])) {
+            $keyColumns = array_unique(array_values($options['primary']));
+            $queryFields .= ', ' . PHP_EOL . '    PRIMARY KEY(' . $this->getIndexFieldDeclarationListSQL($keyColumns) . ')' . PHP_EOL;
+        }
+
+        $query = 'CREATE ';
+        if (!empty($options['temporary'])) {
+            $query .= 'TEMPORARY ';
+        }
+        $query .= 'TABLE `' . $tableName . '` (' . $queryFields . ') ';
+
+        if (isset($options['comment'])) {
+            $comment = trim($options['comment'], " '");
+
+            $query .= sprintf("COMMENT = '%s' ", str_replace("'", "''", $comment));
+        }
+
+        if ( ! isset($options['charset'])) {
+            $options['charset'] = 'utf8';
+        }
+
+        if ( ! isset($options['collate'])) {
+            $options['collate'] = 'utf8_unicode_ci';
+        }
+
+        $query .= 'DEFAULT CHARACTER SET ' . $options['charset'];
+        $query .= ' COLLATE ' . $options['collate'];
+
+        if ( ! isset($options['engine'])) {
+            $options['engine'] = 'InnoDB';
+        }
+        $query .= ' ENGINE = ' . $options['engine'];
+
+        $sql[] = $query;
+
+        if (isset($options['foreignKeys'])) {
+            foreach ((array) $options['foreignKeys'] as $definition) {
+                $sql[] = $this->getCreateForeignKeySQL($definition, $tableName);
+            }
+        }
+
+        return $sql;
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
-    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function initializeDoctrineTypeMappings()
     {
-        return array();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
-    {
-        return array(
-            'ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)
+        $this->doctrineTypeMapping = array(
+            'tinyint'       => 'tinyint',
+            'smallint'      => 'smallint',
+            'mediumint'     => 'mediumint',
+            'int'           => 'integer',
+            'integer'       => 'integer',
+            'bigint'        => 'bigint',
+            'tinytext'      => 'tinytext',
+            'mediumtext'    => 'mediumtext',
+            'longtext'      => 'longtext',
+            'text'          => 'text',
+            'varchar'       => 'varchar',
+            'string'        => 'varchar',
+            'char'          => 'char',
+            'date'          => 'date',
+            'datetime'      => 'datetime',
+            'timestamp'     => 'timestamp',
+            'time'          => 'time',
+            'float'         => 'float',
+            'double'        => 'double',
+            'real'          => 'double',
+            'decimal'       => 'decimal',
+            'numeric'       => 'decimal',
+            'year'          => 'year',
+            'longblob'      => 'blob',
+            'blob'          => 'blob',
+            'mediumblob'    => 'blob',
+            'tinyblob'      => 'blob',
+            'binary'        => 'blob',
+            'varbinary'     => 'blob',
+            'set'           => 'simple_array',
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getReservedKeywordsClass()
-    {
-        return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
     }
 }

--- a/src/Schema/Platform/MySQL57Platform.php
+++ b/src/Schema/Platform/MySQL57Platform.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Copy of the evolution made in Doctrine for MySQL57 by Steve Müller <st.mueller@dzh-online.de>
+ */
+
+namespace Schema\Platform;
+
+use Schema\Platform\MySqlPlatform as SchemaMySqlPlaforme;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MySQL 5.7 database platform.
+ *
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ */
+class MySQL57Platform extends SchemaMySqlPlaforme
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    {
+        return array(
+            'ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
+    }
+}

--- a/src/Schema/Platform/MySQL57Platform.php
+++ b/src/Schema/Platform/MySQL57Platform.php
@@ -51,4 +51,9 @@ class MySQL57Platform extends SchemaMySqlPlaforme
     {
         return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
     }
+
+    public function getTinyIntTypeDeclarationSQL(array $field)
+    {
+        return 'TINYINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+    }
 }

--- a/src/Schema/Platform/MySQL57Platform.php
+++ b/src/Schema/Platform/MySQL57Platform.php
@@ -1,11 +1,12 @@
 <?php
 /*
- * Original code from Axel Etcheverry <axel@etcheverry.biz>
+ *
  */
 
 namespace Schema\Platform;
 
-use Doctrine\DBAL\Platforms\MySQL57Platform as BaseMySqlPlatform;
+use Schema\Platform\MySqlPlatform as SchemaMySqlPlatform;
+
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 
@@ -16,335 +17,39 @@ use Doctrine\DBAL\Schema\TableDiff;
  * @link   www.doctrine-project.org
  * @since  2.5
  */
-class MySQL57Platform extends BaseMySqlPlatform
+class MySQL57Platform extends SchemaMySQLPlatform
 {
-    public function getTinyIntTypeDeclarationSQL(array $field)
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
     {
-        return 'TINYINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
-    }
-
-    protected function _getCommonTextTypeDeclarationSQL(array $columnDef)
-    {
-        if (isset($columnDef['length']) && is_numeric($columnDef['length'])) {
-            return '(' . (int)$columnDef['length'] . ')';
-        }
-
-        return '';
-    }
-
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
-    {
-        $length = '';
-        if (isset($columnDef['length']) && is_numeric($columnDef['length'])) {
-            $length = '(' . (int)$columnDef['length'] . ')';
-        }
-
-        $autoinc = '';
-        if ( ! empty($columnDef['autoincrement'])) {
-            $autoinc = ' AUTO_INCREMENT';
-        }
-        $unsigned = (isset($columnDef['unsigned']) && $columnDef['unsigned']) ? ' UNSIGNED' : '';
-
-        return $length . $unsigned . $autoinc;
-    }
-
-    public function getBooleanTypeDeclarationSQL(array $field)
-    {
-        return 'TINYINT(1) UNSIGNED';
-    }
-
-    public function getDoubleDeclarationSQL(array $field)
-    {
-        return 'DOUBLE' . $this->_getCommonDoubleTypeDeclarationSQL($field);
-    }
-
-    public function getMediumIntTypeDeclarationSQL(array $field)
-    {
-        return 'MEDIUMINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
-    }
-
-    public function getTinyTextTypeDeclarationSQL(array $field)
-    {
-        return 'TINYTEXT' . $this->_getCommonTextTypeDeclarationSQL($field);
-    }
-
-    public function getMediumTextTypeDeclarationSQL(array $field)
-    {
-        return 'MEDIUMTEXT' . $this->_getCommonTextTypeDeclarationSQL($field);
-    }
-
-    public function getLongTextTypeDeclarationSQL(array $field)
-    {
-        return 'LONGTEXT' . $this->_getCommonTextTypeDeclarationSQL($field);
-    }
-
-    public function _getCommonDoubleTypeDeclarationSQL(array $columnDef)
-    {
-        if (!isset($columnDef['precision'], $columnDef['scale'])) {
-            return '';
-        }
-
-
-        $columnDef['precision'] = (!isset($columnDef['precision']) || empty($columnDef['precision']))
-            ? 10 : $columnDef['precision'];
-        $columnDef['scale'] = ( ! isset($columnDef['scale']) || empty($columnDef['scale']))
-            ? 0 : $columnDef['scale'];
-
-        return '(' . $columnDef['precision'] . ', ' . $columnDef['scale'] . ')';
-    }
-
-    public function getDefaultValueDeclarationSQL($field)
-    {
-        $default = empty($field['notnull']) ? ' DEFAULT NULL' : '';
-
-        if (isset($field['default'])) {
-
-            if (isset($field['type'])) {
-                //var_dump((string)$field['type']);
-                if (in_array((string)$field['type'], array("Integer", "BigInteger", "SmallInteger", "Tinyint"))) {
-                    $default = " DEFAULT '" . $field['default'] . "'";
-                } else if ((string)$field['type'] == 'DateTime' && $field['default'] == $this->getCurrentTimestampSQL()) {
-                    $default = " DEFAULT " . $this->getCurrentTimestampSQL();
-                } else if ((string)$field['type'] == 'Timestamp' && $field['default'] == $this->getCurrentTimestampSQL()) {
-                    $default = " DEFAULT " . $this->getCurrentTimestampSQL();
-                } else if ((string) $field['type'] == 'Boolean') {
-                    $default = " DEFAULT '" . $this->convertBooleans($field['default']) . "'";
-                }
-            }
-        }
-        return $default;
-    }
-
-    public function getColumnDeclarationSQL($name, array $field)
-    {
-        if (isset($field['columnDefinition'])) {
-            $columnDef = $this->getCustomTypeDeclarationSQL($field);
-        } else {
-            $default = $this->getDefaultValueDeclarationSQL($field);
-
-            $charset = (isset($field['charset']) && $field['charset']) ?
-                    ' ' . $this->getColumnCharsetDeclarationSQL($field['charset']) : '';
-
-            $collation = (isset($field['collation']) && $field['collation']) ?
-                    ' ' . $this->getColumnCollationDeclarationSQL($field['collation']) : '';
-
-            $notnull = (isset($field['notnull']) && $field['notnull']) ? ' NOT NULL' : '';
-
-            $unique = (isset($field['unique']) && $field['unique']) ?
-                    ' ' . $this->getUniqueFieldDeclarationSQL() : '';
-
-            $check = (isset($field['check']) && $field['check']) ?
-                    ' ' . $field['check'] : '';
-
-            $typeDecl = $field['type']->getSqlDeclaration($field, $this);
-            $columnDef = $typeDecl . $charset . $notnull . $default . $unique . $check . $collation;
-        }
-
-        if ($this->supportsInlineColumnComments() && isset($field['comment']) && $field['comment']) {
-            $columnDef .= " COMMENT '" . $field['comment'] . "'";
-        }
-
-        return '`' . $name . '` ' . $columnDef;
-    }
-
-    public function getColumnDeclarationListSQL(array $fields)
-    {
-        $queryFields = array();
-
-        foreach ($fields as $fieldName => $field) {
-            $queryFields[] = "    " . $this->getColumnDeclarationSQL($fieldName, $field);
-        }
-
-        return PHP_EOL . implode(',' . PHP_EOL, $queryFields);
-
-        /*foreach ($queryFields as $queryField) {
-            $content .= "    " . $queryField . PHP_EOL;
-        }*/
-
-        //return $content;
-
-        //return implode(', ' . PHP_EOL, $queryFields);
-    }
-
-    public function getUniqueConstraintDeclarationSQL($name, Index $index)
-    {
-        if (count($index->getColumns()) === 0) {
-            throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
-        }
-
-        return '    CONSTRAINT `' . $name . '` UNIQUE ('
-             . $this->getIndexFieldDeclarationListSQL($index->getColumns())
-             . ')';
-    }
-
-    public function getIndexDeclarationSQL($name, Index $index)
-    {
-        $type = '';
-
-        if ($index->isUnique()) {
-            $type = 'UNIQUE ';
-        }
-
-        if (count($index->getColumns()) === 0) {
-            throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
-        }
-
-        return '    ' . $type . 'INDEX `' . $name . '` ('
-             . $this->getIndexFieldDeclarationListSQL($index->getColumns())
-             . ')';
-    }
-
-    public function getIndexFieldDeclarationListSQL(array $fields)
-    {
-        $ret = array();
-
-        foreach ($fields as $field => $definition) {
-            if (is_array($definition)) {
-                $ret[] = '`' . $field . '`';
-            } else {
-                $ret[] = '`' . $definition . '`';
-            }
-        }
-
-        return implode(', ', $ret);
-    }
-
-    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
-    {
-        if ($table instanceof Table) {
-            $table = $table->getQuotedName($this);
-        }
-
-        $query = 'ALTER TABLE `' . $table . '` ADD ' . $this->getForeignKeyDeclarationSQL($foreignKey);
-
-        return $query;
-    }
-
-
-    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey)
-    {
-        $sql = '';
-        if (strlen($foreignKey->getName())) {
-            $sql .= 'CONSTRAINT `' . $foreignKey->getQuotedName($this) . '` ';
-        }
-        $sql .= 'FOREIGN KEY (`';
-
-        if (count($foreignKey->getLocalColumns()) === 0) {
-            throw new \InvalidArgumentException("Incomplete definition. 'local' required.");
-        }
-        if (count($foreignKey->getForeignColumns()) === 0) {
-            throw new \InvalidArgumentException("Incomplete definition. 'foreign' required.");
-        }
-        if (strlen($foreignKey->getForeignTableName()) === 0) {
-            throw new \InvalidArgumentException("Incomplete definition. 'foreignTable' required.");
-        }
-
-        $sql .= implode('`, `', $foreignKey->getLocalColumns())
-              . '`) REFERENCES `'
-              . $foreignKey->getQuotedForeignTableName($this) . '` (`'
-              . implode('`, `', $foreignKey->getForeignColumns()) . '`)';
-
-        return $sql;
-    }
-
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = array())
-    {
-        $queryFields = $this->getColumnDeclarationListSQL($columns);
-
-        if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $queryFields .= ', ' . PHP_EOL . $this->getUniqueConstraintDeclarationSQL($index, $definition);
-            }
-        }
-
-        // add all indexes
-        if (isset($options['indexes']) && ! empty($options['indexes'])) {
-            foreach($options['indexes'] as $index => $definition) {
-                $queryFields .= ', ' . PHP_EOL . $this->getIndexDeclarationSQL($index, $definition);
-            }
-        }
-
-        // attach all primary keys
-        if (isset($options['primary']) && ! empty($options['primary'])) {
-            $keyColumns = array_unique(array_values($options['primary']));
-            $queryFields .= ', ' . PHP_EOL . '    PRIMARY KEY(' . $this->getIndexFieldDeclarationListSQL($keyColumns) . ')' . PHP_EOL;
-        }
-
-        $query = 'CREATE ';
-        if (!empty($options['temporary'])) {
-            $query .= 'TEMPORARY ';
-        }
-        $query .= 'TABLE `' . $tableName . '` (' . $queryFields . ') ';
-
-        if (isset($options['comment'])) {
-            $comment = trim($options['comment'], " '");
-
-            $query .= sprintf("COMMENT = '%s' ", str_replace("'", "''", $comment));
-        }
-
-        if ( ! isset($options['charset'])) {
-            $options['charset'] = 'utf8';
-        }
-
-        if ( ! isset($options['collate'])) {
-            $options['collate'] = 'utf8_unicode_ci';
-        }
-
-        $query .= 'DEFAULT CHARACTER SET ' . $options['charset'];
-        $query .= ' COLLATE ' . $options['collate'];
-
-        if ( ! isset($options['engine'])) {
-            $options['engine'] = 'InnoDB';
-        }
-        $query .= ' ENGINE = ' . $options['engine'];
-
-        $sql[] = $query;
-
-        if (isset($options['foreignKeys'])) {
-            foreach ((array) $options['foreignKeys'] as $definition) {
-                $sql[] = $this->getCreateForeignKeySQL($definition, $tableName);
-            }
-        }
-
-        return $sql;
+        return array();
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
     {
-        $this->doctrineTypeMapping = array(
-            'tinyint'       => 'tinyint',
-            'smallint'      => 'smallint',
-            'mediumint'     => 'mediumint',
-            'int'           => 'integer',
-            'integer'       => 'integer',
-            'bigint'        => 'bigint',
-            'tinytext'      => 'tinytext',
-            'mediumtext'    => 'mediumtext',
-            'longtext'      => 'longtext',
-            'text'          => 'text',
-            'varchar'       => 'varchar',
-            'string'        => 'varchar',
-            'char'          => 'char',
-            'date'          => 'date',
-            'datetime'      => 'datetime',
-            'timestamp'     => 'timestamp',
-            'time'          => 'time',
-            'float'         => 'float',
-            'double'        => 'double',
-            'real'          => 'double',
-            'decimal'       => 'decimal',
-            'numeric'       => 'decimal',
-            'year'          => 'year',
-            'longblob'      => 'blob',
-            'blob'          => 'blob',
-            'mediumblob'    => 'blob',
-            'tinyblob'      => 'blob',
-            'binary'        => 'blob',
-            'varbinary'     => 'blob',
-            'set'           => 'simple_array',
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    {
+        return array(
+            'ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
     }
 }

--- a/src/Schema/Platform/MySQL57Platform.php
+++ b/src/Schema/Platform/MySQL57Platform.php
@@ -51,9 +51,4 @@ class MySQL57Platform extends SchemaMySqlPlaforme
     {
         return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
     }
-
-    public function getTinyIntTypeDeclarationSQL(array $field)
-    {
-        return 'TINYINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
-    }
 }

--- a/src/Schema/Platform/MySqlPlatform.php
+++ b/src/Schema/Platform/MySqlPlatform.php
@@ -103,7 +103,7 @@ class MySqlPlatform extends BaseMySqlPlatform
 
             if (isset($field['type'])) {
                 //var_dump((string)$field['type']);
-                if (in_array((string)$field['type'], array("Integer", "BigInteger", "SmallInteger", "Tinyint"))) {
+                if (in_array((string)$field['type'], array("Integer", "BigInteger", "SmallInteger", "Tinyint", "Double","BigInt", "SmallInt"))) {
                     $default = " DEFAULT '" . $field['default'] . "'";
                 } else if ((string)$field['type'] == 'DateTime' && $field['default'] == $this->getCurrentTimestampSQL()) {
                     $default = " DEFAULT " . $this->getCurrentTimestampSQL();

--- a/src/Schema/Type/TinyintType.php
+++ b/src/Schema/Type/TinyintType.php
@@ -25,6 +25,10 @@ class TinyintType extends SmallIntType
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return $platform->getTinyIntTypeDeclarationSQL($fieldDeclaration);
+        if(method_exists($platform,'getTinyIntTypeDeclarationSQL')) {
+            return $platform->getTinyIntTypeDeclarationSQL($fieldDeclaration);
+        } else {
+            return $platform->getSmallIntTypeDeclarationSQL($fieldDeclaration);
+        }
     }
 }

--- a/src/Schema/Type/TinyintType.php
+++ b/src/Schema/Type/TinyintType.php
@@ -25,10 +25,6 @@ class TinyintType extends SmallIntType
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        if(method_exists($platform,'getTinyIntTypeDeclarationSQL')) {
-            return $platform->getTinyIntTypeDeclarationSQL($fieldDeclaration);
-        } else {
-            return $platform->getSmallIntTypeDeclarationSQL($fieldDeclaration);
-        }
+        return $platform->getTinyIntTypeDeclarationSQL($fieldDeclaration);
     }
 }


### PR DESCRIPTION
Add support for MySQL 5.7

* Transpose Doctrine code for MySQL57Platform
* Add switch to the Driver to force using local MySQL57Platform and not Doctrine
* Add new type name that wasn't taken on MySQL57 plateforme with the old code